### PR TITLE
[PLAT-298] adding min-release-age to .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+min-release-age = 14
+save-exact = true


### PR DESCRIPTION
## Why?
PLAT-298: enforce npm release age and ensure exact versioning across healthbridgeltd repositories.

- `min-release-age=14` reduces exposure to supply-chain attacks from freshly published malicious packages.
- `save-exact=true` (if it does not already exist) ensures `npm install <pkg>` saves the exact version, keeping dependency resolution deterministic.

## What?
Appends the following to every `.npmrc` in this repository (creating one at the repo root if none exists; existing lines are left untouched):

```
min-release-age = 14
save-exact = true
```

## Type of change?
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (would cause existing functionality to not work as expected)
- [ ] Requires a documentation update
- [ ] Includes a database migration (Deploy Notes section should inform if migrations should run before or after deployment)

## How to test?
N/A

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have followed the standards related to my specific guild
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have made sure any GDPR changes necessary have been done

## Security
- [ ] PII or clinical data displayed by change will be suppressed from screen recording tools
- [ ] Requires a security review  
- [ ] Security review has been done

## Deploy notes
N/A

## Screenshots (in case of UI change)
N/A
